### PR TITLE
Add `tsu` prefix to use UTC time zone

### DIFF
--- a/src/formatter.js
+++ b/src/formatter.js
@@ -32,19 +32,19 @@ const OUTPUT_FORMAT = {
         format: 'x000000' // momentjs doesn't support ns formatting :(
     },
     ISO:  {
-        title: 'ISO date and time',
+        title: 'ISO date and time ({{TIMEZONE}})',
         format: ''
     },
     SHORT:  {
-        title: 'Short date and time',
+        title: 'Short date and time ({{TIMEZONE}})',
         format: 'L h:mm:ss a'
     },
     LONG:  {
-        title: 'Long date and time',
+        title: 'Long date and time ({{TIMEZONE}})',
         format: 'LLL'
     },
     FULL:  {
-        title: 'Full date and time',
+        title: 'Full date and time ({{TIMEZONE}})',
         format: 'LLLL'
     }
 }
@@ -86,26 +86,34 @@ module.exports.getType = (input) => {
  *
  * @return momentJS
  **/
-module.exports.parse = (input, type) => {
+module.exports.parse = (input, type, isUTC) => {
+    let result;
+
     switch(type) {
         case INPUT_FORMAT.NOW:
-            return moment()
+            result = moment()
             break
         case INPUT_FORMAT.TS_S:
-            return moment.unix(parseInt(input))
+            result = moment.unix(parseInt(input))
             break
         case INPUT_FORMAT.TS_MS:
-            return moment.unix(parseInt(input) / 1000)
+            result = moment.unix(parseInt(input) / 1000)
             break
         case INPUT_FORMAT.TS_NS:
-            return moment.unix(parseInt(input) / 1000000000)
+            result = moment.unix(parseInt(input) / 1000000000)
             break
         case INPUT_FORMAT.ARRAY:
-            return moment(input)
+            result = moment(input)
             break
         default:
-            return moment(input)
+            result = moment(input)
     }
+
+    if (isUTC) {
+        result = result.utc();
+    }
+
+    return result;
 }
 
 /*

--- a/src/index.js
+++ b/src/index.js
@@ -15,15 +15,16 @@ const plugin = ({ term, display, actions }) => {
 
     //fall back on the ts prefix
     if (!match) {
-        match = term.match(/^ts\s(.*)/);
+        match = term.match(/^tsu?\s(.*)/);
     }
 
     if (match) {
+        const isUTC = term.startsWith('tsu');
         const input = match[1];
 
         if (input) {
             const type = getType(input); //String
-            const moment = parse(input, type); //momentJS object
+            const moment = parse(input, type, isUTC); //momentJS object
 
             if (!moment.isValid()) {
                 display({
@@ -74,7 +75,7 @@ const plugin = ({ term, display, actions }) => {
                         id: `cerebro-timestamp-${format.title}`,
                         icon,
                         clipboard: res,
-                        subtitle: format.title,
+                        subtitle: format.title.replace('{{TIMEZONE}}', isUTC ? 'UTC' : 'local time'),
                         onSelect: () => {
                             actions.copyToClipboard(res);
                         }


### PR DESCRIPTION
While working on my project, besides missing nanoseconds precision I often needed timestamps to be parsed in UTC time zone. I'm tired of manually converting that in my head 🙂